### PR TITLE
Implemented GET request to fetch data from Prisma studio

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,5 +1,22 @@
+import { PrismaClient } from '@prisma/client';
 import { NextResponse } from 'next/server';
 
-export const GET = () => {
-	return new NextResponse('Hello world', { status: 200 });
+// WE FETCH ALL THE CATEGORIES FROM PRISMA STUDIO
+
+const prisma = new PrismaClient();
+
+export const GET = async () => {
+	try {
+		const categories = await prisma.category.findMany();
+
+		return new NextResponse(JSON.stringify(categories), {
+			status: 200,
+		});
+	} catch (error) {
+		console.log(error);
+		return new NextResponse(
+			JSON.stringify({ message: 'Something went wrong' }),
+			{ status: 500 }
+		);
+	}
 };


### PR DESCRIPTION
I instantiated Prisma Studio using `npx prisma studio` and went to the Prisma Studio browser using the link: http://localhost:5555. 
Inside the Prisma studio, I added data tables to the Category model we created earlier using information from `menu` in data.ts file in vscode.
I then used the GET request in route.ts inside the `categories` folder in `api` folder to get data from Prisma Studio using the `PrismaClient` method. To check whether the data has been fetched successfully, I went to localhost:3000/api/categories and you should see the data there in `json` format.